### PR TITLE
Updating juspay sdk version

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -47,6 +47,6 @@ android {
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation 'in.juspay:hypersdk:2.0.3-rc.46'
+    implementation 'in.juspay:hypersdk:2.0.4-rc.78'
     implementation "com.simpl.android:fingerprintSDK:1.1.2"
 }


### PR DESCRIPTION
<h2> Description: </h2>

Google has been progressively restricting usage of some permissions widely used thus far to access android system information. So we need to update the android manifest file with QUERY_ALL_PACKAGES permissions.

<h2> Solution: </h2>
juspay SDK has been updated to solve this problem. New SDK version is 2.0.4-rc.78. 

<h2> Links: </h2>
https://support.google.com/googleplay/android-developer/answer/10158779