### PR TITLE
Update HyperSDK version - Play Store Compliance

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -47,6 +47,6 @@ android {
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation 'in.juspay:hypersdk:2.0.4-rc.78'
+    implementation 'in.juspay:hypersdk:2.1.2'
     implementation "com.simpl.android:fingerprintSDK:1.1.2"
 }


### PR DESCRIPTION
Updating hypersdk to [version](https://developer.juspay.in/v2.0/docs/release-notes#version-212-important--mandatory) which solves the google play store compliance. 